### PR TITLE
Implement HTTP routes for API endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
 package main
 
-func main() {
+import "algorithm-1/server"
 
+func main() {
+	server.StartHTTPServer()
 }

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+func Root(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Algorithm 1 REST server is alive!")
+}
+
+func GenerateSchedule(w http.ResponseWriter, r *http.Request) {
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// TODO: Call parsing method and scheduling algorithm
+	// For now, only outputs the body provided (JSON data)
+	// and if it's empty just returns a basic string.
+	if len(reqBody) == 0 {
+		fmt.Fprintf(w, "This will generate a schedule!")
+	} else {
+		fmt.Fprint(w, string(reqBody))
+	}
+}
+
+func CheckSchedule(w http.ResponseWriter, r *http.Request) {
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Fprintf(w, "No body parameters provided")
+	}
+
+	// TODO: Call parsing method and scheduling checking
+	// method. For now, only outputs the body provided
+	// (JSON data), and if it's empty just returns a basic string.
+	if len(reqBody) == 0 {
+		fmt.Fprintf(w, "This will check a schedule is valid!")
+	} else {
+		fmt.Fprint(w, string(reqBody))
+	}
+}
+
+func StartHTTPServer() {
+	// Define all routes for REST API
+	http.HandleFunc("/", Root)
+	http.HandleFunc("/generate_schedule", GenerateSchedule)
+	http.HandleFunc("/check_schedule", CheckSchedule)
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/tests/unit-tests/server_test.go
+++ b/tests/unit-tests/server_test.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"algorithm-1/server"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TODO: Write unit tests for generate schedule & check schedule
+// when implementation is done.
+
+func TestRootRoute(t *testing.T) {
+	// Setup
+	request, _ := http.NewRequest(http.MethodGet, "/", nil)
+	response := httptest.NewRecorder()
+
+	// Act
+	server.Root(response, request)
+
+	// Assert
+	actual_response := response.Body.String()
+	expected_response := "Algorithm 1 REST server is alive!"
+
+	if actual_response != expected_response {
+		t.Errorf("got %q, want %q", actual_response, expected_response)
+	}
+}


### PR DESCRIPTION
Added root, generate_schedule, and check_schedule HTTP methods to provide us with an API endpoint we can hit. Actual calls to algorithm or parsing is not implemented here.