### PR TITLE
Connect API endpoint to historical schedule parsing

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"algorithm-1/structs"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -21,14 +22,29 @@ func GenerateSchedule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Call parsing method and scheduling algorithm
-	// For now, only outputs the body provided (JSON data)
-	// and if it's empty just returns a basic string.
 	if len(reqBody) == 0 {
-		fmt.Fprintf(w, "This will generate a schedule!")
-	} else {
-		fmt.Fprint(w, string(reqBody))
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Request body cannot be empty."))
+		return
 	}
+
+	parsedSchedule, err := structs.ParseHistorical(reqBody)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	schedule2019 := structs.Schedule2019(parsedSchedule)
+
+	marshalledJSON, err := structs.StructToJSON(schedule2019)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	fmt.Fprint(w, string(marshalledJSON))
 }
 
 func CheckSchedule(w http.ResponseWriter, r *http.Request) {

--- a/structs/parsing.go
+++ b/structs/parsing.go
@@ -5,21 +5,21 @@ import (
 	"regexp"
 )
 
-func ParseHistorical(jsonData []byte) Schedule {
+func ParseHistorical(jsonData []byte) (Schedule, error) {
 	var parsedSchedule Schedule
 
 	err := json.Unmarshal(jsonData, &parsedSchedule)
 
 	if err != nil {
-		panic(err)
+		return parsedSchedule, err
 	}
 
-	return parsedSchedule
+	return parsedSchedule, nil
 }
 
 func Schedule2019(schedule Schedule) Schedule {
 	var schedule2019 Schedule
-	
+
 	for _, x := range schedule.FallCourses {
 		match, _ := regexp.MatchString("Sep .., 2018", x.Assignment.StartDate)
 		if match {
@@ -42,37 +42,35 @@ func Schedule2019(schedule Schedule) Schedule {
 	return schedule2019
 }
 
-func ParseCourses(jsonData []byte) []Course {
+func ParseCourses(jsonData []byte) ([]Course, error) {
 	var courses []Course
 	err := json.Unmarshal(jsonData, &courses)
 	if err != nil {
-		panic(err)
+		return courses, err
 	}
 
-	return courses
+	return courses, nil
 }
 
-func ParseProfPreferences(jsonData []byte) []Professor {
+func ParseProfPreferences(jsonData []byte) ([]Professor, error) {
 	var profs []Professor
 
 	err := json.Unmarshal(jsonData, &profs)
 
 	if err != nil {
-		panic(err)
+		return profs, err
 	}
 
-	return profs
+	return profs, nil
 }
 
-
-func StructToJSON(schedule Schedule) []byte {
+func StructToJSON(schedule Schedule) ([]byte, error) {
 
 	jsonData, err := json.Marshal(schedule)
 
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return jsonData
+	return jsonData, nil
 }
-

--- a/tests/unit-tests/parsing_test.go
+++ b/tests/unit-tests/parsing_test.go
@@ -55,7 +55,11 @@ func TestSmallHistoricalParse(t *testing.T) {
 			"summerTermCourses": []
 		}`)
 
-	testSchedule := structs.ParseHistorical(jsonData)
+	testSchedule, err := structs.ParseHistorical(jsonData)
+
+	if err != nil {
+		t.Error("Schedule parsing failed with error: ", err.Error())
+	}
 
 	if testSchedule.FallCourses == nil {
 		t.Error("Schedule failed to be parsed")
@@ -83,7 +87,11 @@ func TestLargeHistoricalParse(t *testing.T) {
 			"summerTermCourses": []
 		}`)
 
-	testSchedule = structs.ParseHistorical(jsonData)
+	testSchedule, err := structs.ParseHistorical(jsonData)
+
+	if err != nil {
+		t.Error("Schedule parsing failed with error: ", err.Error())
+	}
 
 	if testSchedule.FallCourses == nil {
 		t.Error("Schedule failed to be parsed")
@@ -106,7 +114,11 @@ func TestCourseParse(t *testing.T) {
 			"sequenceNumber": "A01",
 			"courseTitle": "ALGORITHMS+DATA STUCT:I"
 		}]`)
-	result := structs.ParseCourses(jsonData)
+	result, err := structs.ParseCourses(jsonData)
+
+	if err != nil {
+		t.Error("Parsing courses failed with error: ", err.Error())
+	}
 
 	if result[0].CourseNumber != "115" {
 		t.Error("Incorrect CourseNumber")
@@ -189,7 +201,11 @@ func TestJSONGeneration(t *testing.T) {
 		"summerTermCourses":[]
 	}`
 
-	jsonData := structs.StructToJSON(testSchedule)
+	jsonData, err := structs.StructToJSON(testSchedule)
+
+	if err != nil {
+		t.Error("Schedule parsing failed with error: ", err.Error())
+	}
 
 	// Remove whitespace and newlines for testing
 	jsonString = strings.Replace(jsonString, "\n", "", -1)
@@ -199,7 +215,6 @@ func TestJSONGeneration(t *testing.T) {
 		t.Error("Schedule failed to parse to JSON correctly")
 	}
 }
-
 
 func TestProfParse(t *testing.T) {
 	// example input
@@ -225,7 +240,11 @@ func TestProfParse(t *testing.T) {
 				]
 			}
 		]`)
-	result := structs.ParseProfPreferences(jsonData)
+	result, err := structs.ParseProfPreferences(jsonData)
+
+	if err != nil {
+		t.Error("Parsing professor preferences failed with error: ", err.Error())
+	}
 
 	if result[0].DisplayName != "Berg, Celina" {
 		t.Error("Incorrect Prof Name")


### PR DESCRIPTION
This performs parsing of historical schedule and returns desired courses when calling `/generate_schedule` API method. To provide better error handling, I also refactored parsing methods to return errors so it can be handled and info can be returned to the caller.