### PR TITLE
Changed the timeslot map value type to slices

### DIFF
--- a/structs/structs.go
+++ b/structs/structs.go
@@ -53,14 +53,14 @@ type Preference struct {
 	Term          string `json:"term,omitempty"`
 }
 
-// Should follow key = start time, value = subject and course number
+// Should follow key = start time, value = list of subject and course number strings
 // Ex. Calling *.Monday["1130"] returns "CSC 115"
 type Timeslots struct {
-	Sunday    map[string]string
-	Monday    map[string]string
-	Tuesday   map[string]string
-	Wednesday map[string]string
-	Thursday  map[string]string
-	Friday    map[string]string
-	Saturday  map[string]string
+	Sunday    map[string][]string
+	Monday    map[string][]string
+	Tuesday   map[string][]string
+	Wednesday map[string][]string
+	Thursday  map[string][]string
+	Friday    map[string][]string
+	Saturday  map[string][]string
 }


### PR DESCRIPTION
Realized having multiple courses at the same time could not be represented very well just using string type. Having a slice of strings allows for multiple courses to be assigned to a timeslot.