### PR TITLE
Hotfix - Add logic to require a stream sequence in a course

### DIFF
--- a/scheduling/timeslots.go
+++ b/scheduling/timeslots.go
@@ -94,6 +94,8 @@ func AddCoursesToStreamMaps(courses []structs.Course, timeslotMaps structs.Strea
 			updatedCourse, timeslotMaps.S4A, err = addMultipleTimeslots(course, timeslotMaps.S4A)
 		} else if course.StreamSequence == "4B" {
 			updatedCourse, timeslotMaps.S4B, err = addMultipleTimeslots(course, timeslotMaps.S4B)
+		} else {
+			err = fmt.Errorf("error: %v %v has no stream sequence value", course.Subject, course.CourseNumber)
 		}
 
 		if err != nil {

--- a/tests/unit-tests/timeslot_test.go
+++ b/tests/unit-tests/timeslot_test.go
@@ -184,6 +184,45 @@ func TestCantScheduleClassOutsideTime(t *testing.T) {
 	}
 }
 
+func TestCantScheduleCourseWithoutStreamSequence(t *testing.T) {
+	// Test data
+	testAssignment := structs.Assignment{
+		StartDate: "Sep 05, 2018",
+		EndDate:   "Dec 05, 2018",
+		BeginTime: "0300",
+		EndTime:   "0420",
+		HoursWeek: 3,
+		Sunday:    false,
+		Monday:    true,
+		Tuesday:   false,
+		Wednesday: false,
+		Thursday:  true,
+		Friday:    false,
+		Saturday:  false,
+	}
+
+	testCourse := structs.Course{
+		Assignment:     testAssignment,
+		CourseNumber:   "101",
+		Subject:        "CHEM",
+		SequenceNumber: "A01",
+		StreamSequence: "",
+		CourseTitle:    "Properties of Materials",
+	}
+
+	testSchedule := structs.Schedule{
+		FallCourses:   []structs.Course{testCourse},
+		SpringCourses: []structs.Course{},
+		SummerCourses: []structs.Course{},
+	}
+
+	_, err := scheduling.BaseTimeslotMaps(testSchedule.FallCourses)
+
+	if err == nil {
+		t.Error("Error: Did not catch course being scheduled without stream sequence")
+	}
+}
+
 func TestFullRandomAssignment(t *testing.T) {
 	allChanged := true
 


### PR DESCRIPTION
Added logic that will throw an error if stream sequence is not specified. Added a test to make sure error is thrown as well.