### PR TITLE
Hotfix - Full Schedule Tests Update

### DIFF
--- a/tests/data/input-test.json
+++ b/tests/data/input-test.json
@@ -228,8 +228,8 @@
         "meetingTime": {
           "startDate": "Jan 07, 2019",
           "endDate": "Apr 05, 2019",
-          "beginTime": "1530",
-          "endTime": "1650",
+          "beginTime": "1430",
+          "endTime": "1550",
           "hoursWeek": 3,
           "sunday": false,
           "monday": true,

--- a/tests/data/input-test.json
+++ b/tests/data/input-test.json
@@ -220,30 +220,6 @@
         }
       },
       {
-        "courseNumber": "141",
-        "subject": "ENGR",
-        "sequenceNumber": "A02",
-        "streamSequence": "1B",
-        "courseTitle": "Engineering Mechanics",
-        "meetingTime": {
-          "startDate": "Jan 07, 2019",
-          "endDate": "Apr 05, 2019",
-          "beginTime": "1430",
-          "endTime": "1550",
-          "hoursWeek": 3,
-          "sunday": false,
-          "monday": true,
-          "tuesday": false,
-          "wednesday": false,
-          "thursday": true,
-          "friday": false,
-          "saturday": false
-        },
-        "prof": {
-          "displayName": "TBD"
-        }
-      },
-      {
         "courseNumber": "101",
         "subject": "MATH",
         "sequenceNumber": "A01",

--- a/tests/unit-tests/full_schedule_assignment_test.go
+++ b/tests/unit-tests/full_schedule_assignment_test.go
@@ -58,10 +58,17 @@ func TestFallScheduleAssignment(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	testSchedule.FallCourses, _, _ = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.FallCourses), testStreamtype)
+	testSchedule.FallCourses, _, err = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.FallCourses), testStreamtype)
+	if err != nil {
+		t.Error(err)
+	}
 	testScheduleCourse := scheduling.AssignCourseProf(input.HardScheduled.FallCourses, testSchedule.FallCourses, input.Professors)
 	err = scheduling.ScheduleConstraintsCheck("Fall", testScheduleCourse, input.Professors)
-
+	if err != nil {
+		t.Error(err)
+	}
+	testScheduleCourse = append(testScheduleCourse, input.HardScheduled.FallCourses...)
+	_, err = scheduling.BaseTimeslotMaps(testScheduleCourse)
 	if err != nil {
 		t.Error(err)
 	}
@@ -74,10 +81,17 @@ func TestSpringScheduleAssignment(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	testSchedule.SpringCourses, _, _ = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.SpringCourses), testStreamtype)
+	testSchedule.SpringCourses, _, err = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.SpringCourses), testStreamtype)
+	if err != nil {
+		t.Error(err)
+	}
 	testScheduleCourse := scheduling.AssignCourseProf(input.HardScheduled.SpringCourses, testSchedule.SpringCourses, input.Professors)
 	err = scheduling.ScheduleConstraintsCheck("Spring", testScheduleCourse, input.Professors)
-
+	if err != nil {
+		t.Error(err)
+	}
+	testScheduleCourse = append(testScheduleCourse, input.HardScheduled.SpringCourses...)
+	_, err = scheduling.BaseTimeslotMaps(testScheduleCourse)
 	if err != nil {
 		t.Error(err)
 	}
@@ -90,10 +104,17 @@ func TestSummerScheduleAssignment(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	testSchedule.SummerCourses, _, _ = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.SummerCourses), testStreamtype)
+	testSchedule.SummerCourses, _, err = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.SummerCourses), testStreamtype)
+	if err != nil {
+		t.Error(err)
+	}
 	testScheduleCourse := scheduling.AssignCourseProf(input.HardScheduled.SummerCourses, testSchedule.SummerCourses, input.Professors)
 	err = scheduling.ScheduleConstraintsCheck("Summer", testScheduleCourse, input.Professors)
-
+	if err != nil {
+		t.Error(err)
+	}
+	testScheduleCourse = append(testScheduleCourse, input.HardScheduled.SummerCourses...)
+	_, err = scheduling.BaseTimeslotMaps(testScheduleCourse)
 	if err != nil {
 		t.Error(err)
 	}

--- a/tests/unit-tests/full_schedule_assignment_test.go
+++ b/tests/unit-tests/full_schedule_assignment_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func getInput(t *testing.T) (structs.Schedule, structs.Input){
+func getInput(t *testing.T) (structs.Schedule, structs.Input) {
 	jsonData, err := ioutil.ReadFile("../data/input-test.json")
 	if err != nil {
 		log.Fatal("Error when opening input-test.json file: ", err)
@@ -38,14 +38,14 @@ func getInput(t *testing.T) (structs.Schedule, structs.Input){
 	return testSchedule, input
 }
 
-func printAssignments(testScheduleCourse []structs.Course, prefsMap map[string]map[string]int){
-	for _,c := range testScheduleCourse{
-		fmt.Println(c.Subject, c.CourseNumber, c.CourseTitle, c.SequenceNumber,"in sequence", c.StreamSequence)
-		fmt.Println("\t taught by:", c.Prof.DisplayName, "( preference:", prefsMap[c.Prof.DisplayName][c.Subject+c.CourseNumber],")" )
-		fmt.Println("\t\t at", c.Assignment.BeginTime ,"to",c.Assignment.EndTime )
-		if(c.Assignment.Monday == true){
+func printAssignments(testScheduleCourse []structs.Course, prefsMap map[string]map[string]int) {
+	for _, c := range testScheduleCourse {
+		fmt.Println(c.Subject, c.CourseNumber, c.CourseTitle, c.SequenceNumber, "in sequence", c.StreamSequence)
+		fmt.Println("\t taught by:", c.Prof.DisplayName, "( preference:", prefsMap[c.Prof.DisplayName][c.Subject+c.CourseNumber], ")")
+		fmt.Println("\t\t at", c.Assignment.BeginTime, "to", c.Assignment.EndTime)
+		if c.Assignment.Monday == true {
 			fmt.Println("\t\t\t on MTh")
-		}else {
+		} else {
 			fmt.Println("\t\t\t on TWF")
 		}
 	}
@@ -54,10 +54,13 @@ func printAssignments(testScheduleCourse []structs.Course, prefsMap map[string]m
 func TestFallScheduleAssignment(t *testing.T) {
 
 	testSchedule, input := getInput(t)
-	testStreamtype := scheduling.CreateEmptyStreamType()
+	testStreamtype, err := scheduling.BaseTimeslotMaps(input.HardScheduled.FallCourses)
+	if err != nil {
+		t.Error(err)
+	}
 	testSchedule.FallCourses, _, _ = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.FallCourses), testStreamtype)
 	testScheduleCourse := scheduling.AssignCourseProf(input.HardScheduled.FallCourses, testSchedule.FallCourses, input.Professors)
-	err := scheduling.ScheduleConstraintsCheck("Fall", testScheduleCourse, input.Professors)
+	err = scheduling.ScheduleConstraintsCheck("Fall", testScheduleCourse, input.Professors)
 
 	if err != nil {
 		t.Error(err)
@@ -67,10 +70,13 @@ func TestFallScheduleAssignment(t *testing.T) {
 func TestSpringScheduleAssignment(t *testing.T) {
 
 	testSchedule, input := getInput(t)
-	testStreamtype := scheduling.CreateEmptyStreamType()
+	testStreamtype, err := scheduling.BaseTimeslotMaps(input.HardScheduled.SpringCourses)
+	if err != nil {
+		t.Error(err)
+	}
 	testSchedule.SpringCourses, _, _ = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.SpringCourses), testStreamtype)
 	testScheduleCourse := scheduling.AssignCourseProf(input.HardScheduled.SpringCourses, testSchedule.SpringCourses, input.Professors)
-	err := scheduling.ScheduleConstraintsCheck("Spring", testScheduleCourse, input.Professors)
+	err = scheduling.ScheduleConstraintsCheck("Spring", testScheduleCourse, input.Professors)
 
 	if err != nil {
 		t.Error(err)
@@ -80,10 +86,13 @@ func TestSpringScheduleAssignment(t *testing.T) {
 func TestSummerScheduleAssignment(t *testing.T) {
 
 	testSchedule, input := getInput(t)
-	testStreamtype := scheduling.CreateEmptyStreamType()
+	testStreamtype, err := scheduling.BaseTimeslotMaps(input.HardScheduled.SummerCourses)
+	if err != nil {
+		t.Error(err)
+	}
 	testSchedule.SummerCourses, _, _ = scheduling.AddCoursesToStreamMaps(scheduling.Split(testSchedule.SummerCourses), testStreamtype)
 	testScheduleCourse := scheduling.AssignCourseProf(input.HardScheduled.SummerCourses, testSchedule.SummerCourses, input.Professors)
-	err := scheduling.ScheduleConstraintsCheck("Summer", testScheduleCourse, input.Professors)
+	err = scheduling.ScheduleConstraintsCheck("Summer", testScheduleCourse, input.Professors)
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Added more error catching and checks into the full schedule test. Added in hard scheduled courses being added into the map before the test, and the hard scheduled courses being appended to the list at the end. Also removed a course from the hard scheduled test input that didn't follow our timeslots.