### PR TITLE
Hot fix where split was being used

### DIFF
--- a/scheduling/timeslots.go
+++ b/scheduling/timeslots.go
@@ -67,7 +67,7 @@ func CreateEmptyStreamType() structs.StreamType {
 func BaseTimeslotMaps(baseTermCourses []structs.Course) (structs.StreamType, error) {
 	timeslotMaps := CreateEmptyStreamType()
 
-	_, timeslotMaps, err := AddCoursesToStreamMaps(Split(baseTermCourses), timeslotMaps)
+	_, timeslotMaps, err := AddCoursesToStreamMaps(baseTermCourses, timeslotMaps)
 
 	return timeslotMaps, err
 }


### PR DESCRIPTION
Removed split being called in BaseTimeSlotMaps. Sometimes it seems that BaseTimeSlotMaps is being called with hardScheduled data. Since we don't want to split hardScheduled data I removed splitting courses from this function. Splitting of function will only be used in Assignments() in scheduling.go. Or tests that mimic assignments.