### PR TITLE
Hotfix/handle 2 or 1 courses

### DIFF
--- a/genetic/genetic-structs.go
+++ b/genetic/genetic-structs.go
@@ -162,7 +162,7 @@ func (sem Semester) Mutate(rng *rand.Rand) {
 
 // Crossover a Semester with another Semester by using Partially Mixed Crossover (PMX).
 func (sem Semester) Crossover(q eaopt.Genome, rng *rand.Rand) {
-	eaopt.CrossGNX(sem, q.(Semester), 3, rng)
+	eaopt.CrossGNX(sem, q.(Semester), 2, rng)
 }
 
 // MakeSemester creates a random semester

--- a/server/main.go
+++ b/server/main.go
@@ -64,7 +64,7 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Run genetic algorithm on each semester, will update to run concurrently
-	if len(parsedInput.CoursesToSchedule.FallCourses) != 0 {
+	if len(parsedInput.CoursesToSchedule.FallCourses) > 1 {
 		schedule.FallCourses, err = genetic.RunGeneticAlg(parsedInput.HardScheduled.FallCourses, parsedInput.CoursesToSchedule.FallCourses, parsedInput.Professors, "Fall")
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -74,7 +74,7 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 	} else {
 		schedule.FallCourses = fallBackup
 	}
-	if len(parsedInput.CoursesToSchedule.SpringCourses) != 0 {
+	if len(parsedInput.CoursesToSchedule.SpringCourses) > 1 {
 		schedule.SpringCourses, err = genetic.RunGeneticAlg(parsedInput.HardScheduled.SpringCourses, parsedInput.CoursesToSchedule.SpringCourses, parsedInput.Professors, "Spring")
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -84,7 +84,7 @@ func Generate(w http.ResponseWriter, r *http.Request) {
 	} else {
 		schedule.SpringCourses = springBackup
 	}
-	if len(parsedInput.CoursesToSchedule.SummerCourses) != 0 {
+	if len(parsedInput.CoursesToSchedule.SummerCourses) > 1 {
 		schedule.SummerCourses, err = genetic.RunGeneticAlg(parsedInput.HardScheduled.SummerCourses, parsedInput.CoursesToSchedule.SummerCourses, parsedInput.Professors, "Summer")
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
Currently the algorithm crashes when asked to assign 1 or 2 courses. This fix changes our cross over to use 2 point crossovers instead of 3 so the algorithm can handle 2 courses. Due to the nature of the algorithm, 1 course can't be run through (not much to optimize) so if one course is detected it will be assigned to a random slot.