### PR TITLE
Hotfix - Hardscheduled courses not updating their dates

### DIFF
--- a/genetic/genetic-structs.go
+++ b/genetic/genetic-structs.go
@@ -173,7 +173,11 @@ func MakeSemester(rng *rand.Rand) eaopt.Genome {
 	testStreamtype, _ := scheduling.BaseTimeslotMaps(hardScheduled, term)
 	coursesToSchedule, _, _ = scheduling.AddCoursesToStreamMaps(scheduling.Split(coursesToSchedule), testStreamtype, term)
 	testScheduleCourse := scheduling.AssignCourseProf(hardScheduled, coursesToSchedule, professors, term)
-	testScheduleCourse = append(testScheduleCourse, hardScheduled...)
+
+	emptyMap := scheduling.CreateEmptyStreamType()
+	hardCourses, _, _ := scheduling.AddCoursesToStreamMaps(hardScheduled, emptyMap, term)
+
+	testScheduleCourse = append(testScheduleCourse, hardCourses...)
 
 	testSem := make(Semester, len(testScheduleCourse))
 

--- a/scheduling/scheduling.go
+++ b/scheduling/scheduling.go
@@ -64,7 +64,14 @@ func Assignments(hardScheduledCourses []structs.Course, requestedCourses []struc
 		return nil, err
 	}
 	requestedCourses = AssignCourseProf(hardScheduledCourses, requestedCourses, professors, term)
-	requestedCourses = append(requestedCourses, hardScheduledCourses...)
+
+	emptyMap := CreateEmptyStreamType()
+	hardCourses, _, err := AddCoursesToStreamMaps(hardScheduledCourses, emptyMap, term)
+	if err != nil {
+		return nil, err
+	}
+
+	requestedCourses = append(requestedCourses, hardCourses...)
 
 	return requestedCourses, err
 }


### PR DESCRIPTION
Fixed just appending the hardscheduled courses to running them through their own timeslot addition. Should just update the dates and not touch their other values.

Closes #182 