### PR TITLE
pref with or without term feature

### DIFF
--- a/scheduling/professors.go
+++ b/scheduling/professors.go
@@ -4,8 +4,8 @@ import (
 	"algorithm-1/structs"
 	"fmt"
 	"math/rand"
-	"time"
 	"strings"
+	"time"
 )
 
 func randomizer(profList []string) []string {
@@ -32,11 +32,14 @@ func MapPreferences(profs []structs.Professor, term string) (map[string]map[stri
 		
 		// set profList
 		profList = append(profList, s.DisplayName)
+		term = strings.ToUpper(term)
 
 		// set prof preference map
 		prefsMap[s.DisplayName] = map[string]int{}
 		for _, x := range s.Preferences {
-			prefsMap[s.DisplayName][x.CourseNum] = int(x.PreferenceNum)
+			if x.Term == "" || x.Term == term {
+				prefsMap[s.DisplayName][x.CourseNum] = int(x.PreferenceNum)
+			}
 		}
 
 		// set max prefered courses to teach


### PR DESCRIPTION
- Modified MapPreferences() to add professor preferences based on inputted specified Term.
- Therefore preference are only added to the preference map when the Term input matches the semester being scheduled
- Likewise if Term is not specified for a given course (ie null or "") then preference for that course will be added to every semester when scheduling. 
- This change satisfies input for including and excluding the "Term" field in the preferences list for teach prof object.