### PR TITLE
Updated constraints check

### DIFF
--- a/tests/unit-tests/server_test.go
+++ b/tests/unit-tests/server_test.go
@@ -65,7 +65,7 @@ func TestCheckScheduleProfFail(t *testing.T) {
 
 	// Assert
 	actual_response := response.Body.String()
-	expected_response := "error: Bird, Bill teaching another Fall course at MTh1300,   Schedule given has some violations that should be resolved"
+	expected_response := "Error: Bird, Bill teaching another Fall course at MTh1300. Prof cannot two classes at the same time.\nSchedule given has some violations that should be resolved"
 
 	if actual_response != expected_response {
 		t.Errorf("got %q, want %q", actual_response, expected_response)


### PR DESCRIPTION
- updated wording for error messages
- found and fixed bug that set number of courses preferences to be summerTermCourses
- removed check that ensured prof taught all sections of course in check function
- Prof will still be assigned to all sections of a given course for as many sections they can teach that semester based on they preferred max, but check will not enforce this constraint. This will give admin more flexibility to change courses after generation.
- Constraints check will only be enforced on missing course assignment, double prof slotting, zero preference assignment, and assigning profs over their preferred max courses to teach a semester.