### PR TITLE
check-prof-exist

### DIFF
--- a/scheduling/professors.go
+++ b/scheduling/professors.go
@@ -201,6 +201,21 @@ func ScheduleConstraintsCheck(term string,
 			break
 		}
 
+		isProf := false
+		for _, prof := range profList {
+			// check that profs do not teach more than prefered amount of courses
+			if prof == c.Prof.DisplayName || c.Prof.DisplayName == "TBD" {
+				fmt.Println(c.Prof.DisplayName, "TRUE")
+				isProf = true
+				break
+			}
+		}
+
+		if !isProf {
+			err = fmt.Errorf("Error: %v assigned to %v %v is not an actual professor.\n", c.Prof.DisplayName, term, c.Subject+c.CourseNumber)
+			break
+		}
+
 		// check for double slotted prof
 		if _, found := teachingTimeslotMap[c.Prof.DisplayName+d]; found {
 			err = fmt.Errorf("Error: %v teaching another %v course at %v. Prof cannot two classes at the same time.\n", c.Prof.DisplayName, term, d)

--- a/scheduling/professors.go
+++ b/scheduling/professors.go
@@ -205,7 +205,6 @@ func ScheduleConstraintsCheck(term string,
 		for _, prof := range profList {
 			// check that profs do not teach more than prefered amount of courses
 			if prof == c.Prof.DisplayName || c.Prof.DisplayName == "TBD" {
-				fmt.Println(c.Prof.DisplayName, "TRUE")
 				isProf = true
 				break
 			}

--- a/scheduling/professors.go
+++ b/scheduling/professors.go
@@ -201,15 +201,16 @@ func ScheduleConstraintsCheck(term string,
 			break
 		}
 
+		// check that course prof is in proflist given and that prof isn't TBD
 		isProf := false
 		for _, prof := range profList {
-			// check that profs do not teach more than prefered amount of courses
 			if prof == c.Prof.DisplayName || c.Prof.DisplayName == "TBD" {
 				isProf = true
 				break
 			}
 		}
 
+		// if prof doesn't exist then throw err
 		if !isProf {
 			err = fmt.Errorf("Error: %v assigned to %v %v is not an actual professor.\n", c.Prof.DisplayName, term, c.Subject+c.CourseNumber)
 			break

--- a/tests/data/not-real-prof-test.json
+++ b/tests/data/not-real-prof-test.json
@@ -1,0 +1,121 @@
+{
+    "hardScheduled": {
+      "fallCourses": [
+        {
+          "courseNumber": "310",
+          "subject": "SENG",
+          "sequenceNumber": "A01",
+          "streamSequence": "2B",
+          "courseTitle": "HCI",
+          "numSections": 1,
+          "courseCapacity": 100,
+          "assignment": {
+            "startDate": "Sep 05, 2018",
+            "endDate": "Dec 05, 2018",
+            "beginTime": "1000",
+            "endTime": "1120",
+            "hoursWeek": 3,
+            "sunday": false,
+            "monday": true,
+            "tuesday": false,
+            "wednesday": false,
+            "thursday": true,
+            "friday": false,
+            "saturday": false
+          },
+          "prof": {
+            "displayName": "Birdy, Bill",
+            "preferences": []
+          }
+        },
+        {
+          "courseNumber": "275",
+          "subject": "SENG",
+          "sequenceNumber": "A01",
+          "streamSequence": "2B",
+          "courseTitle": "Test",
+          "numSections": 1,
+          "courseCapacity": 100,
+          "assignment": {
+            "startDate": "Sep 05, 2018",
+            "endDate": "Dec 05, 2018",
+            "beginTime": "1300",
+            "endTime": "1420",
+            "hoursWeek": 3,
+            "sunday": false,
+            "monday": true,
+            "tuesday": false,
+            "wednesday": false,
+            "thursday": true,
+            "friday": false,
+            "saturday": false
+          },
+          "prof": {
+            "displayName": "TBD",
+            "preferences": []
+          }
+        },
+        {
+          "courseNumber": "111",
+          "subject": "CSC",
+          "sequenceNumber": "A01",
+          "streamSequence": "1A",
+          "courseTitle": "Test",
+          "numSections": 1,
+          "courseCapacity": 100,
+          "assignment": {
+            "startDate": "Sep 05, 2018",
+            "endDate": "Dec 05, 2018",
+            "beginTime": "0830",
+            "endTime": "950",
+            "hoursWeek": 3,
+            "sunday": false,
+            "monday": true,
+            "tuesday": false,
+            "wednesday": false,
+            "thursday": true,
+            "friday": false,
+            "saturday": false
+          },
+          "prof": {
+            "displayName": "Corless, Jason",
+            "preferences": []
+          }
+        }
+      ],
+      "springCourses": [],
+      "summerCourses": []
+    },
+    "coursesToSchedule": {
+      "fallCourses": [],
+      "springCourses": [],
+      "summerCourses": []
+    },
+    "professors": [
+      {
+        "displayName": "Bird, Bill",
+        "fallTermCourses": 2,
+        "springTermCourses": 2,
+        "summerTermCourses": 2,
+        "preferences": [
+          {
+            "courseNum": "SENG310",
+            "preferenceNum": 6
+          }
+        ]
+      },
+      {
+        "displayName": "Corless, Jason",
+        "fallTermCourses": 2,
+        "springTermCourses": 2,
+        "summerTermCourses": 2,
+        "preferences": [
+          {
+            "courseNum": "CSC111",
+            "preferenceNum": 6
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/tests/unit-tests/server_test.go
+++ b/tests/unit-tests/server_test.go
@@ -93,3 +93,25 @@ func TestCheckScheduleTimeslotFail(t *testing.T) {
 		t.Errorf("got %q, want %q", actual_response, expected_response)
 	}
 }
+
+func TestCheckScheduleImaginaryProf(t *testing.T) {
+	// Setup
+	jsonFile, err := os.Open("../data/not-real-prof.json")
+	if err != nil {
+		t.Error("File not found")
+	}
+
+	request, _ := http.NewRequest(http.MethodPost, "/CheckSchedule", jsonFile)
+	response := httptest.NewRecorder()
+
+	// Act
+	server.CheckSchedule(response, request)
+
+	// Assert
+	actual_response := response.Body.String()
+	expected_response := "Error: Birdy, Bill assigned to Fall SENG310 is not an actual professor.\nSchedule given has some violations that should be resolved"
+
+	if actual_response != expected_response {
+		t.Errorf("got %q, want %q", actual_response, expected_response)
+	}
+}

--- a/tests/unit-tests/server_test.go
+++ b/tests/unit-tests/server_test.go
@@ -96,7 +96,7 @@ func TestCheckScheduleTimeslotFail(t *testing.T) {
 
 func TestCheckScheduleImaginaryProf(t *testing.T) {
 	// Setup
-	jsonFile, err := os.Open("../data/not-real-prof.json")
+	jsonFile, err := os.Open("../data/not-real-prof-test.json")
 	if err != nil {
 		t.Error("File not found")
 	}


### PR DESCRIPTION
- added check to constraint check that ensures that scheduled prof is actually a prof in the prof list.
- this way typos in professor displayNames in schedule will produce an invalid schedule
- added alg1 unit test too